### PR TITLE
Try generalising additional roles

### DIFF
--- a/assets/conf/local/Caddyfile.rolemapper
+++ b/assets/conf/local/Caddyfile.rolemapper
@@ -1,0 +1,74 @@
+{
+  http_port     8080
+  https_port    8443
+  debug
+}
+
+localhost, 127.0.0.1 {
+  route /auth* {
+    auth_portal {
+      backends {
+        local_backend1 {
+          method local
+          path assets/conf/local/auth/user_db.json
+          realm firstlocal
+        }
+        local_backend2 {
+          method local
+          path assets/conf/local/auth/user_db.json
+          realm secondlocal
+
+          # these only apply to this "secondlocal" realm
+          # this is an extension of what was coded for only the oauth2 backend
+          user "^webadmin" regex add role secondlocal_regex
+          user webadmin@localdomain.local add role secondlocal_add
+        }
+      }
+      rolemapping {
+        # these are global to all backends
+        user "^webadmin" regex add role rolemapping_regex
+        user webadmin@localdomain.local add role rolemapping_add
+
+        path assets/conf/local/auth/rolemapper.json
+      }
+    }
+  }
+
+  route /prometheus* {
+    jwt {
+      primary yes
+      trusted_tokens {
+        static_secret {
+          token_name access_token
+          token_secret 0e2fdcf8-6868-41a7-884b-7308795fc286
+        }
+      }
+      auth_url /auth
+      allow roles anonymous guest admin
+      allow roles superadmin
+      allow roles AzureAD_Administrator AzureAD_Editor AzureAD_Viewer
+      allow roles everyone Everyone
+    }
+    uri strip_prefix /prometheus
+    reverse_proxy http://127.0.0.1:9080
+  }
+
+  route /alertmanager* {
+    jwt
+    uri strip_prefix /alertmanager
+    reverse_proxy http://127.0.0.1:9083
+  }
+
+  route /myapp* {
+    jwt
+    respond * "myapp" 200
+  }
+
+  route /version* {
+    respond * "1.0.0" 200
+  }
+
+  route {
+    redir https://{hostport}/auth 302
+  }
+}

--- a/assets/conf/local/Caddyfile.rolemapper.short
+++ b/assets/conf/local/Caddyfile.rolemapper.short
@@ -1,0 +1,57 @@
+{
+  http_port     8080
+  https_port    8443
+  debug
+}
+
+localhost, 127.0.0.1 {
+  route /auth* {
+    auth_portal {
+      local_backend assets/conf/local/auth/user_db.json
+      rolemapping {
+        user "^webadmin" regex add role rolemapping_regex
+        user webadmin@localdomain.local add role rolemapping_add
+
+        path assets/conf/local/auth/rolemapper.json
+      }
+    }
+  }
+
+  route /prometheus* {
+    jwt {
+      primary yes
+      trusted_tokens {
+        static_secret {
+          token_name access_token
+          token_secret 0e2fdcf8-6868-41a7-884b-7308795fc286
+        }
+      }
+      auth_url /auth
+      allow roles anonymous guest admin
+      allow roles superadmin
+      allow roles AzureAD_Administrator AzureAD_Editor AzureAD_Viewer
+      allow roles everyone Everyone
+    }
+    uri strip_prefix /prometheus
+    reverse_proxy http://127.0.0.1:9080
+  }
+
+  route /alertmanager* {
+    jwt
+    uri strip_prefix /alertmanager
+    reverse_proxy http://127.0.0.1:9083
+  }
+
+  route /myapp* {
+    jwt
+    respond * "myapp" 200
+  }
+
+  route /version* {
+    respond * "1.0.0" 200
+  }
+
+  route {
+    redir https://{hostport}/auth 302
+  }
+}

--- a/assets/conf/local/auth/rolemapper.json
+++ b/assets/conf/local/auth/rolemapper.json
@@ -1,0 +1,9 @@
+[
+    {
+        "email": "webadmin@localdomain.local",
+        "match": "exact",
+        "roles": [
+            "fileadminlocaldomain"
+        ]
+    }
+]

--- a/assets/docs/pages/90-misc.md
+++ b/assets/docs/pages/90-misc.md
@@ -131,3 +131,56 @@ Replaces:
       ...
     }
 ```
+
+### Adding Role Claims globally
+
+The Caddyfile `rolemapping` { `user` } directive allows adding roles to
+a user based on the user's email.
+
+These mappings apply to all authentication backends in an auth_portal, and match on the `email`
+claim.
+
+A user with email claim of `contoso.com` would get an additional `superuser` role.
+
+```
+          user jsmith@contoso.com add role superuser
+```
+
+A user with the email address beginning with `jsmith` would get additional roles.
+Specifically, it would be viewer, editor, and admin.
+
+```
+          user "^greenpau" regex add roles viewer editor admin
+```
+
+All users with `contoso.com` email address would get "employee" role:
+
+```
+          user "@contoso.com$" regex add role employee
+
+```
+
+The user role mapping can also be managed using a json file specified using the 
+`path` directive, using the following format:
+
+```
+[
+  { email: "jsmith@contoso.com", match: "exact", roles: ["superuser"] },
+  { email: "^greenpau", match: "regex", roles: ["viewer", "editor", "admin"] },
+  { email: "@contoso.com$", match: "regex", roles: ["employee"] },
+]
+```
+
+For example, your Caddyfile may be as follows:
+
+```
+myapp.localdomain.local, localhost, 127.0.0.1 {
+  route /auth* {
+    auth_portal {
+      path /auth
+      rolemapping {
+        user "^greenpau" regex add role superuser
+        user jsmith@contoso.com add role superuser
+        path /config/caddy/rolemapping/map.json
+      }
+```

--- a/authenticate_test.go
+++ b/authenticate_test.go
@@ -1,0 +1,283 @@
+package portal
+
+import (
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	jwtclaims "github.com/greenpau/caddy-auth-jwt/pkg/claims"
+	"github.com/greenpau/caddy-auth-portal/pkg/core"
+	"go.uber.org/zap"
+
+	"github.com/caddyserver/caddy/v2/caddytest"
+)
+
+func TestAuthenticateShortLocalCaddyfile(t *testing.T) {
+	scheme := "https"
+	host := "127.0.0.1"
+	securePort := "8443"
+	authPath := "auth"
+	hostPort := host + ":" + securePort
+	baseURL := scheme + "://" + hostPort
+	tester := caddytest.NewTester(t)
+	configFile := "assets/conf/local/Caddyfile.short"
+	configContent, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load configuration file %s: %s", configFile, err)
+	}
+	rawConfig := string(configContent)
+	tester.InitServer(rawConfig, "caddyfile")
+
+	if core.PortalManager.MemberCount != 1 {
+		t.Errorf("expected one AuthPortal, got %d", core.PortalManager.MemberCount)
+	}
+	p := core.PortalManager.Members[0]
+
+	logger := zap.NewExample()
+
+	reqBackendRealm := "local"
+	reqBackendMethod := "POST"
+
+	opts := make(map[string]interface{})
+	opts["auth_credentials"] = map[string]string{
+		"username": "webadmin",
+		"password": "password123",
+	}
+	expectedRoles := []string{
+		"superadmin",
+		"anonymous",
+		"guest",
+	}
+
+	for _, backend := range p.Backends {
+		if backend.GetRealm() != reqBackendRealm {
+			continue
+		}
+		//opts["request"] = r
+		opts["request_path"] = path.Join(p.AuthURLPath, reqBackendMethod, reqBackendRealm)
+		resp, err := backend.Authenticate(opts)
+		if err != nil {
+			t.Errorf("Authenticate failed: %s", err)
+		}
+		claims := resp["claims"].(*jwtclaims.UserClaims)
+		p.RoleMappers.Logger = logger
+		p.RoleMappers.ApplyRoleMapToClaims(claims, backend.GetRealm())
+		if len(claims.Roles) != 3 {
+			// original code results in superadmin,anonymous,guest
+			t.Errorf("Expected %d role (%s) got : %s",
+				len(expectedRoles),
+				strings.Join(expectedRoles, ","),
+				strings.Join(claims.Roles, ","),
+			)
+		}
+	}
+
+	tester.AssertGetResponse(baseURL+"/version", 200, "1.0.0")
+	req, _ := http.NewRequest(
+		"POST",
+		baseURL+"/"+authPath,
+		strings.NewReader("username=webadmin&password=password123&realm=local"),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp := tester.AssertResponseCode(req, 200)
+	t.Logf("%v", resp)
+	time.Sleep(1 * time.Second)
+
+	// faking it - the init() in portal.go is only going to be called once...
+	core.PortalManager = &core.AuthPortalManager{}
+}
+
+func TestAuthenticateRolemapperShortLocalCaddyfile(t *testing.T) {
+	scheme := "https"
+	host := "127.0.0.1"
+	securePort := "8443"
+	authPath := "auth"
+	hostPort := host + ":" + securePort
+	baseURL := scheme + "://" + hostPort
+	tester := caddytest.NewTester(t)
+	configFile := "assets/conf/local/Caddyfile.rolemapper.short"
+	configContent, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load configuration file %s: %s", configFile, err)
+	}
+	rawConfig := string(configContent)
+	tester.InitServer(rawConfig, "caddyfile")
+
+	if core.PortalManager.MemberCount != 1 {
+		t.Errorf("expected one AuthPortal, got %d", core.PortalManager.MemberCount)
+	}
+	p := core.PortalManager.Members[0]
+
+	logger := zap.NewExample()
+
+	reqBackendRealm := "local"
+	reqBackendMethod := "POST"
+
+	opts := make(map[string]interface{})
+	opts["auth_credentials"] = map[string]string{
+		"username": "webadmin",
+		"password": "password123",
+	}
+
+	expectedRoles := []string{
+		"superadmin",
+		"anonymous",
+		"guest",
+		"rolemapping_regex",
+		"rolemapping_add",
+		"fileadminlocaldomain",
+	}
+
+	for _, backend := range p.Backends {
+		if backend.GetRealm() != reqBackendRealm {
+			continue
+		}
+		//opts["request"] = r
+		opts["request_path"] = path.Join(p.AuthURLPath, reqBackendMethod, reqBackendRealm)
+		resp, err := backend.Authenticate(opts)
+		if err != nil {
+			t.Errorf("Authenticate failed: %s", err)
+		}
+		claims := resp["claims"].(*jwtclaims.UserClaims)
+		p.RoleMappers.Logger = logger
+		p.RoleMappers.ApplyRoleMapToClaims(claims, backend.GetRealm())
+		if len(claims.Roles) != len(expectedRoles) {
+			// original code results in superadmin,anonymous,guest
+			t.Errorf("Expected %d role (%s) got : %s",
+				len(expectedRoles),
+				strings.Join(expectedRoles, ","),
+				strings.Join(claims.Roles, ","),
+			)
+		}
+	}
+
+	tester.AssertGetResponse(baseURL+"/version", 200, "1.0.0")
+	req, _ := http.NewRequest(
+		"POST",
+		baseURL+"/"+authPath,
+		strings.NewReader("username=webadmin&password=password123&realm=local"),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp := tester.AssertResponseCode(req, 200)
+	t.Logf("%v", resp)
+	time.Sleep(1 * time.Second)
+
+	// faking it - the init() in portal.go is only going to be called once...
+	core.PortalManager = &core.AuthPortalManager{}
+}
+
+// the long version uses the expanded version of the local_backend caddyfile cfg
+// and has 2 local_backends to show the different role mappings
+func TestAuthenticateRolemapperLocalCaddyfile(t *testing.T) {
+	tester := caddytest.NewTester(t)
+	configFile := "assets/conf/local/Caddyfile.rolemapper"
+	configContent, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to load configuration file %s: %s", configFile, err)
+	}
+	rawConfig := string(configContent)
+	tester.InitServer(rawConfig, "caddyfile")
+
+	if core.PortalManager.MemberCount != 1 {
+		t.Errorf("expected one AuthPortal, got %d", core.PortalManager.MemberCount)
+	}
+	p := core.PortalManager.Members[0]
+
+	logger := zap.NewExample()
+
+	{
+		reqBackendRealm := "firstlocal"
+		reqBackendMethod := "POST"
+
+		opts := make(map[string]interface{})
+		opts["auth_credentials"] = map[string]string{
+			"username": "webadmin",
+			"password": "password123",
+		}
+
+		expectedRoles := []string{
+			"superadmin",
+			"anonymous",
+			"guest",
+			"rolemapping_regex",
+			"rolemapping_add",
+			"fileadminlocaldomain",
+		}
+
+		for _, backend := range p.Backends {
+			if backend.GetRealm() != reqBackendRealm {
+				continue
+			}
+			//opts["request"] = r
+			opts["request_path"] = path.Join(p.AuthURLPath, reqBackendMethod, reqBackendRealm)
+			resp, err := backend.Authenticate(opts)
+			if err != nil {
+				t.Errorf("Authenticate failed: %s", err)
+			}
+			claims := resp["claims"].(*jwtclaims.UserClaims)
+			p.RoleMappers.Logger = logger
+			p.RoleMappers.ApplyRoleMapToClaims(claims, backend.GetRealm())
+			if len(claims.Roles) != len(expectedRoles) {
+				// original code results in superadmin,anonymous,guest
+				t.Errorf("Expected %d role (%s) got : %s",
+					len(expectedRoles),
+					strings.Join(expectedRoles, ","),
+					strings.Join(claims.Roles, ","),
+				)
+			}
+		}
+	}
+
+	{
+		reqBackendRealm := "secondlocal"
+		reqBackendMethod := "POST"
+
+		opts := make(map[string]interface{})
+		opts["auth_credentials"] = map[string]string{
+			"username": "webadmin",
+			"password": "password123",
+		}
+
+		expectedRoles := []string{
+			"superadmin",
+			"anonymous",
+			"guest",
+			"rolemapping_regex",
+			"rolemapping_add",
+			"fileadminlocaldomain",
+			"secondlocal_regex",
+			"secondlocal_add",
+		}
+
+		for _, backend := range p.Backends {
+			if backend.GetRealm() != reqBackendRealm {
+				continue
+			}
+			//opts["request"] = r
+			opts["request_path"] = path.Join(p.AuthURLPath, reqBackendMethod, reqBackendRealm)
+			resp, err := backend.Authenticate(opts)
+			if err != nil {
+				t.Errorf("Authenticate failed: %s", err)
+			}
+			claims := resp["claims"].(*jwtclaims.UserClaims)
+			p.RoleMappers.Logger = logger
+			p.RoleMappers.ApplyRoleMapToClaims(claims, backend.GetRealm())
+			if len(claims.Roles) != len(expectedRoles) {
+				// original code results in superadmin,anonymous,guest
+				t.Errorf("Expected %d role (%s) got : %s",
+					len(expectedRoles),
+					strings.Join(expectedRoles, ","),
+					strings.Join(claims.Roles, ","),
+				)
+			}
+		}
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// faking it - the init() in portal.go is only going to be called once...
+	core.PortalManager = &core.AuthPortalManager{}
+}

--- a/pkg/rolemapper/rolemapper.go
+++ b/pkg/rolemapper/rolemapper.go
@@ -1,0 +1,261 @@
+package rolemapper
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"time"
+
+	jwtclaims "github.com/greenpau/caddy-auth-jwt/pkg/claims"
+
+	"go.uber.org/zap"
+)
+
+// RoleMap stores each role mapping data loaded from the conf
+type RoleMap struct {
+	Email  string   `json:"email,omitempty"`
+	Match  string   `json:"match,omitempty"`
+	Roles  []string `json:"roles,omitempty"`
+	Realms []string `json:"realms,omitempty"` // if set, then only apply this mapper to the specified realms/backends.
+}
+
+type implInterface interface {
+	GetRoleMap() ([]RoleMap, error)
+}
+
+// StaticImpl contains a fixed list of RoleMaps
+type StaticImpl struct {
+	RoleMapping []RoleMap `json:"users,omitempty"`
+}
+
+// GetRoleMap returns the list of RoleMaps
+func (impl StaticImpl) GetRoleMap() ([]RoleMap, error) {
+	return impl.RoleMapping, nil
+}
+
+// FileImpl contains a list of RoleMaps loaded from files
+type FileImpl struct {
+	RoleMappingPaths []string `json:"paths,omitempty"`
+	loadedFileTimes  []time.Time
+
+	mappingCache []StaticImpl
+	Logger       *zap.Logger
+}
+
+// LoadFromFile will load the RoleMap conf from for the specified file (idx) into its rolemap cache list
+func (impl *FileImpl) LoadFromFile(idx int) error {
+	path := impl.RoleMappingPaths[idx]
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("failed to create local database file at %s: %s", path, err)
+		}
+		return fmt.Errorf("failed obtaining information about local database file at %s: %s", path, err)
+	}
+
+	if fileInfo.IsDir() {
+		return fmt.Errorf("local database file path points to a directory")
+	}
+
+	if impl.loadedFileTimes[idx] == fileInfo.ModTime() {
+		return nil
+	}
+
+	impl.loadedFileTimes[idx] = fileInfo.ModTime()
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	var m []RoleMap
+	err = json.Unmarshal(content, &m)
+	if err != nil {
+		return err
+	}
+	impl.mappingCache[idx].RoleMapping = m
+	return nil
+}
+
+// GetRoleMap returns the list of RoleMaps loaded from files - will reload if the file changed
+func (impl *FileImpl) GetRoleMap() ([]RoleMap, error) {
+	var allRoleMaps []RoleMap
+	for idx, path := range impl.RoleMappingPaths {
+		if err := impl.LoadFromFile(idx); err != nil {
+			impl.Logger.Error("loading file based rolemap",
+				zap.String("path", path),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		m, err := impl.mappingCache[idx].GetRoleMap()
+		if err != nil {
+			impl.Logger.Error("calling GetRoleMap",
+				zap.String("path", path),
+				zap.Error(err),
+			)
+		}
+		allRoleMaps = append(allRoleMaps, m...)
+	}
+
+	return allRoleMaps, nil
+}
+
+// RoleMapper holds all the role mappers for an AuthPortal
+type RoleMapper struct {
+	Impls []implInterface
+
+	Logger *zap.Logger
+}
+
+// AddStaticImpl adds a new Static RoleMapper from a list of RoleMaps
+func (r *RoleMapper) AddStaticImpl(m []RoleMap) {
+	r.Impls = append(r.Impls, StaticImpl{
+		RoleMapping: m,
+	})
+}
+
+// AddFileImpl adds a new File based RoleMapper from a list of paths
+func (r *RoleMapper) AddFileImpl(p []string) {
+	r.Impls = append(r.Impls, &FileImpl{
+		RoleMappingPaths: p,
+		loadedFileTimes:  make([]time.Time, len(p)),
+		mappingCache:     make([]StaticImpl, len(p)),
+		Logger:           r.Logger,
+	})
+}
+
+// UnmarshalJSON unpacks configuration into appropriate structures.
+func (r *RoleMapper) UnmarshalJSON(data []byte) error {
+	var confData map[string]interface{}
+	if err := json.Unmarshal(data, &confData); err != nil {
+		return fmt.Errorf("failed to unpack RoleMapper configuration data: %s", data)
+	}
+
+	if _, exists := confData["Impls"]; !exists || confData["Impls"] == nil {
+		return nil
+	}
+	implData, ok := confData["Impls"].([]interface{})
+	if !ok {
+		return fmt.Errorf("type assertion of Impl failed: %v", confData["Impls"])
+	}
+
+	for _, m := range implData {
+		mapper, ok := m.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("type assertion of mapper failed: %v", m)
+		}
+
+		if v, exists := mapper["paths"]; exists {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf("Marshal of paths failed: %v\nError: %s", v, err)
+			}
+			var paths []string
+			if err := json.Unmarshal(b, &paths); err != nil {
+				return fmt.Errorf("failed to unpack usermap data: %s", b)
+			}
+
+			r.AddFileImpl(paths)
+		}
+		if v, exists := mapper["users"]; exists {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return fmt.Errorf("Marshal of users failed: %v\nError: %s", v, err)
+			}
+			var usermap []RoleMap
+			if err := json.Unmarshal(b, &usermap); err != nil {
+				return fmt.Errorf("failed to unpack usermap data: %s", b)
+			}
+
+			r.AddStaticImpl(usermap)
+		}
+	}
+
+	return nil
+}
+
+// ApplyRoleMapToClaims adds roles from the rolemappings to the authenticated user's claim
+func (r *RoleMapper) ApplyRoleMapToClaims(claims *jwtclaims.UserClaims, realm string) {
+	for _, impl := range r.Impls {
+		implRoleMap, err := impl.GetRoleMap()
+		if err != nil {
+			r.Logger.Error("Failed to GetRoleMap from %s: %s", zap.Any("impl", impl), zap.Error(err))
+			continue
+		}
+		r.Logger.Debug("GetRoleMap", zap.Any("impl", impl), zap.Any("roles", implRoleMap))
+
+		applyRoleMapToClaims(implRoleMap, claims, realm)
+	}
+}
+
+func applyRoleMapToClaims(rm []RoleMap, claims *jwtclaims.UserClaims, realm string) {
+	if len(rm) < 1 {
+		return
+	}
+
+	userID := claims.Email
+	if userID == "" {
+		// the github oauth2 case...
+		userID = claims.Subject
+	}
+	if userID == "" {
+		return
+	}
+
+	roles := []string{}
+	roleMap := make(map[string]interface{})
+	for _, roleName := range claims.Roles {
+		roleMap[roleName] = true
+		roles = append(roles, roleName)
+	}
+
+	for _, entry := range rm {
+		// used to support the backend specific rolemappers (for eg, the original oauth2 code)
+		if len(entry.Realms) > 0 {
+			skip := true
+			for _, v := range entry.Realms {
+				if v == realm {
+					skip = false
+				}
+			}
+			if skip {
+				continue
+			}
+		}
+
+		entryEmail := entry.Email
+		entryMatchType := entry.Match
+
+		switch entryMatchType {
+		case "regex":
+			// Perform regex match
+			matched, err := regexp.MatchString(entryEmail, userID)
+			if err != nil {
+				continue
+			}
+			if !matched {
+				continue
+			}
+		case "exact":
+			// Perform exact match
+			if entryEmail != userID {
+				continue
+			}
+		default:
+			continue
+		}
+		entryRoles := entry.Roles
+		for _, r := range entryRoles {
+			roleName := r
+			if _, exists := roleMap[roleName]; !exists {
+				roleMap[roleName] = true
+				roles = append(roles, roleName)
+			}
+		}
+	}
+	claims.Roles = roles
+}


### PR DESCRIPTION
as an example of dealing with #84 - I've copied the code from the user -> roles code in the oath2 backend so it can be used for any (well, all) backends

the next step would be to add some other way of importing the options - from files (like the local user backend), from a database table, etc.

What do you think?