### PR TITLE
Add ability to specify cookie lifetime

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -111,6 +111,13 @@ func parseCaddyfileAuthPortal(h httpcaddyfile.Helper) ([]httpcaddyfile.ConfigVal
 			case "cookie_path":
 				args := h.RemainingArgs()
 				portal.Cookies.Path = args[0]
+			case "cookie_lifetime":
+				args := h.RemainingArgs()
+				lifetime, err := strconv.Atoi(args[0])
+				if err != nil {
+					return nil, h.Errf("%s argument value conversion failed: %s", rootDirective, err)
+				}
+				portal.Cookies.Lifetime = lifetime
 			case "path":
 				args := h.RemainingArgs()
 				portal.AuthURLPath = args[0]

--- a/pkg/cookies/cookie.go
+++ b/pkg/cookies/cookie.go
@@ -15,14 +15,16 @@
 package cookies
 
 import (
+	"fmt"
 	"strings"
 )
 
 // Cookies represent a common set of configuration settings
 // applicable to the cookies issued by the plugin.
 type Cookies struct {
-	Domain string `json:"domain,omitempty"`
-	Path   string `json:"path,omitempty"`
+	Domain   string `json:"domain,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Lifetime int    `json:"lifetime,omitempty"`
 }
 
 // GetAttributes returns cookie attributes.
@@ -35,6 +37,9 @@ func (c *Cookies) GetAttributes() string {
 		sb.WriteString(" Path=" + c.Path + ";")
 	} else {
 		sb.WriteString(" Path=/;")
+	}
+	if c.Lifetime != 0 {
+		sb.WriteString(" Max-Age=" + fmt.Sprint(c.Lifetime) + ";")
 	}
 	sb.WriteString(" Secure; HttpOnly;")
 	return sb.String()


### PR DESCRIPTION
Closes #90

I hereby consent to the Individual CLA provided in assets/cla/individual_cla.md

- Exposes the option `cookie_lifetime` which lets you set the `Max-Age` value for the cookie, overriding the default value of `Session` meaning you can stay logged in for longer times

Only thing I haven't done is edit the unit tests in `caddyfile_test.go` 😬 