### PR TITLE
Update download URLs (1.4.5 > 1.4.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Please see other relevant plugins:
 
 Download Caddy with the plugins enabled:
 
-* <a href="https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com%2Fgreenpau%2Fcaddy-auth-jwt%40v1.2.7&p=github.com%2Fgreenpau%2Fcaddy-auth-portal%40v1.4.5&p=github.com%2Fgreenpau%2Fcaddy-trace%40v1.1.6" target="_blank">linux/amd64</a>
-* <a href="https://caddyserver.com/api/download?os=windows&arch=amd64&p=github.com%2Fgreenpau%2Fcaddy-auth-jwt%40v1.2.7&p=github.com%2Fgreenpau%2Fcaddy-auth-portal%40v1.4.5&p=github.com%2Fgreenpau%2Fcaddy-trace%40v1.1.6" target="_blank">windows/amd64</a>
+* <a href="https://caddyserver.com/api/download?os=linux&arch=amd64&p=github.com%2Fgreenpau%2Fcaddy-auth-jwt%40v1.2.7&p=github.com%2Fgreenpau%2Fcaddy-auth-portal%40v1.4.6&p=github.com%2Fgreenpau%2Fcaddy-trace%40v1.1.6" target="_blank">linux/amd64</a>
+* <a href="https://caddyserver.com/api/download?os=windows&arch=amd64&p=github.com%2Fgreenpau%2Fcaddy-auth-jwt%40v1.2.7&p=github.com%2Fgreenpau%2Fcaddy-auth-portal%40v1.4.6&p=github.com%2Fgreenpau%2Fcaddy-trace%40v1.1.6" target="_blank">windows/amd64</a>
 
 Please show your appreciation for this work and :star: :star: :star:
 


### PR DESCRIPTION
The download URLs in the README didn't point to the latest caddy-auth-portal release 1.4.6, but to 1.4.5 instead.
All other plugins were using an up-to-date version.