### PR TITLE
Replace Apache boilerplate fields with placeholders.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 Paul Greenberg greenpau@outlook.com
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This template isn't intended to be changed in the LICENSE file.  Individual
contributions may maintain the author's copyright in lieu of explicit
copyright grant.  (But the Apache license grants great flexibility, so lack
of a copyright grant generally isn't limiting to how things can be used.)