### PR TITLE
Bump minimum Go version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         platform: [ubuntu-latest]
     name: Build
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Caddy requires Go 1.15 or higher