### PR TITLE
🐛 fix: Fix SAML redirect code (302, not 200)

### DIFF
--- a/pkg/backends/saml/authenticate.go
+++ b/pkg/backends/saml/authenticate.go
@@ -29,7 +29,7 @@ import (
 func (b *Backend) Authenticate(r *requests.Request) error {
 	r.Response.Code = 400
 	if r.Upstream.Request.Method != "POST" {
-		r.Response.Code = 200
+		r.Response.Code = 302
 		r.Response.RedirectURL = b.loginURL
 		return nil
 	}


### PR DESCRIPTION
Currently, when a GET request is made to a SAML endpoint, the incorrect response code `200` is used, causing the `handleHTTPExternalLogin` method to not redirect a user to the authorisation server.

This change changes the response code to `302`, allowing the `http.StatusFound` branch to be triggered, redirecting the user to the correct page.

I hereby consent to the Individual CLA provided in assets/cla/individual_cla.md