### PR TITLE
Allow superadmin to access the settings page

### DIFF
--- a/pkg/authn/handle_http_settings.go
+++ b/pkg/authn/handle_http_settings.go
@@ -63,7 +63,7 @@ func (p *Authenticator) handleHTTPSettings(ctx context.Context, w http.ResponseW
 		return p.handleHTTPLogoutWithLocalRedirect(ctx, w, r, rr)
 	}
 
-	if permitted := usr.HasRole("authp/admin", "authp/user"); !permitted {
+	if permitted := usr.HasRole("authp/admin", "authp/user", "superadmin"); !permitted {
 		return p.handleHTTPError(ctx, w, r, rr, http.StatusForbidden)
 	}
 


### PR DESCRIPTION
At the moment, a user that has the `superadmin` role but not the `authp/admin` role can't access the settings page. This PR allows just a superadmin to access the page as well.

When migrating from before the `authp` roles to the new system, the user in `users.json` is just a superadmin, and doesn't have the `authp/admin` role, which I imagine is what caused this issue.