### PR TITLE
Add ProxyFromEnvironment when using custom Transport

### DIFF
--- a/pkg/backends/oauth2/authenticate.go
+++ b/pkg/backends/oauth2/authenticate.go
@@ -265,6 +265,7 @@ func newBrowser() (*http.Client, error) {
 	   }
 	*/
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 5 * time.Second,
 		}).Dial,


### PR DESCRIPTION
The [default transport](https://pkg.go.dev/net/http?utm_source=godoc#DefaultTransport) used in the go http.Client uses the `ProxyFromEnvironment` function to configure a proxy from env vars, if present. Right now, this behaviour is lost when using a custom Transport in the `newBrowser` function, which is used for a few oauth2 requests.

To ensure that the plugin can make these requests if a proxy connection is required, I added this functionality to the Transport used here.