### PR TITLE
Strip login hint from redirect URL when present

### DIFF
--- a/pkg/authn/respond_http.go
+++ b/pkg/authn/respond_http.go
@@ -222,7 +222,7 @@ func (p *Authenticator) injectRedirectURL(ctx context.Context, w http.ResponseWr
 	if r.Method == "GET" {
 		q := r.URL.Query()
 		if redirectURL, exists := q["redirect_url"]; exists {
-			c := p.cookie.GetCookie(p.cookie.Referer, redirectURL[0])
+			c := p.cookie.GetCookie(p.cookie.Referer, utils.StripQueryParam(redirectURL[0], "login_hint"))
 			p.logger.Debug(
 				"redirect recorded",
 				zap.String("session_id", rr.Upstream.SessionID),

--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authn
 
 import (
@@ -27,13 +41,13 @@ func (w *mockResponseWriter) WriteHeader(int) {}
 func TestInjectRedirectURL(t *testing.T) {
 
 	t.Run("Strips login hint from redirect URL if present", func(t *testing.T) {
-		reqUrl := url.URL{
+		reqURL := url.URL{
 			Scheme:   "https",
 			Host:     "foo.bar",
 			Path:     "/myPage",
 			RawQuery: "redirect_url=https%3A%2F%2Ffoo.bar%2Fredir%3Flogin_hint%3Dmy%40email.com",
 		}
-		r := http.Request{URL: &reqUrl, Method: "GET"}
+		r := http.Request{URL: &reqURL, Method: "GET"}
 		f, _ := cookie.NewFactory(nil)
 		p := Authenticator{
 			Name:   "someAuthenticator",

--- a/pkg/authn/respond_http_test.go
+++ b/pkg/authn/respond_http_test.go
@@ -1,0 +1,52 @@
+package authn
+
+import (
+	"context"
+	"github.com/greenpau/caddy-auth-portal/internal/tests"
+	"github.com/greenpau/caddy-auth-portal/pkg/cookie"
+	"github.com/greenpau/go-identity/pkg/requests"
+	"go.uber.org/zap"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type mockResponseWriter struct{}
+
+func (w *mockResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (w *mockResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func (w *mockResponseWriter) WriteHeader(int) {}
+
+func TestInjectRedirectURL(t *testing.T) {
+
+	t.Run("Strips login hint from redirect URL if present", func(t *testing.T) {
+		reqUrl := url.URL{
+			Scheme:   "https",
+			Host:     "foo.bar",
+			Path:     "/myPage",
+			RawQuery: "redirect_url=https%3A%2F%2Ffoo.bar%2Fredir%3Flogin_hint%3Dmy%40email.com",
+		}
+		r := http.Request{URL: &reqUrl, Method: "GET"}
+		f, _ := cookie.NewFactory(nil)
+		p := Authenticator{
+			Name:   "someAuthenticator",
+			logger: zap.L(),
+			cookie: f,
+		}
+		request := requests.NewRequest()
+
+		p.injectRedirectURL(context.Background(), &mockResponseWriter{}, &r, request)
+
+		cookieParts := strings.Split(request.Response.RedirectURL, ";")
+		tests.EvalObjectsWithLog(t, "redirect url", "AUTHP_REDIRECT_URL=https://foo.bar/redir", cookieParts[0], []string{})
+
+	})
+
+}

--- a/pkg/utils/redirect.go
+++ b/pkg/utils/redirect.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"net/http"
+	urlpkg "net/url"
 	"strings"
 )
 
@@ -97,4 +98,16 @@ func GetCurrentBaseURL(r *http.Request) string {
 	}
 
 	return redirectBaseURL
+}
+
+// StripQueryParam removes a specific query parameter from a URL.
+func StripQueryParam(url string, param string) string {
+	u, err := urlpkg.Parse(url)
+	if err != nil {
+		return url
+	}
+	q := u.Query()
+	q.Del(param)
+	u.RawQuery = q.Encode()
+	return u.String()
 }

--- a/pkg/utils/redirect_test.go
+++ b/pkg/utils/redirect_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"github.com/greenpau/caddy-auth-portal/internal/tests"
+	"testing"
+)
+
+func TestStripQueryParam(t *testing.T) {
+
+	t.Run("removes a specific query param from a URL", func(t *testing.T) {
+		originalUrl := "https://foo.bar/myPage?param1=value&param2=otherValue"
+		alteredUrl := StripQueryParam(originalUrl, "param2")
+		tests.EvalObjectsWithLog(t, "stripped url", "https://foo.bar/myPage?param1=value", alteredUrl, []string{})
+	})
+
+	t.Run("returns original URL if URL cannot be parsed", func(t *testing.T) {
+		originalUrl := "glibberish"
+		alteredUrl := StripQueryParam(originalUrl, "myParam")
+		tests.EvalObjectsWithLog(t, "stripped url", originalUrl, alteredUrl, []string{})
+	})
+
+	t.Run("returns original URL if param does not exist in URL", func(t *testing.T) {
+		originalUrl := "https://foo.bar/myPage?param1=value"
+		alteredUrl := StripQueryParam(originalUrl, "myParam")
+		tests.EvalObjectsWithLog(t, "stripped url", originalUrl, alteredUrl, []string{})
+	})
+
+}

--- a/pkg/utils/redirect_test.go
+++ b/pkg/utils/redirect_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Paul Greenberg greenpau@outlook.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (
@@ -8,21 +22,21 @@ import (
 func TestStripQueryParam(t *testing.T) {
 
 	t.Run("removes a specific query param from a URL", func(t *testing.T) {
-		originalUrl := "https://foo.bar/myPage?param1=value&param2=otherValue"
-		alteredUrl := StripQueryParam(originalUrl, "param2")
-		tests.EvalObjectsWithLog(t, "stripped url", "https://foo.bar/myPage?param1=value", alteredUrl, []string{})
+		originalURL := "https://foo.bar/myPage?param1=value&param2=otherValue"
+		alteredURL := StripQueryParam(originalURL, "param2")
+		tests.EvalObjectsWithLog(t, "stripped url", "https://foo.bar/myPage?param1=value", alteredURL, []string{})
 	})
 
 	t.Run("returns original URL if URL cannot be parsed", func(t *testing.T) {
-		originalUrl := "glibberish"
-		alteredUrl := StripQueryParam(originalUrl, "myParam")
-		tests.EvalObjectsWithLog(t, "stripped url", originalUrl, alteredUrl, []string{})
+		originalURL := "glibberish"
+		alteredURL := StripQueryParam(originalURL, "myParam")
+		tests.EvalObjectsWithLog(t, "stripped url", originalURL, alteredURL, []string{})
 	})
 
 	t.Run("returns original URL if param does not exist in URL", func(t *testing.T) {
-		originalUrl := "https://foo.bar/myPage?param1=value"
-		alteredUrl := StripQueryParam(originalUrl, "myParam")
-		tests.EvalObjectsWithLog(t, "stripped url", originalUrl, alteredUrl, []string{})
+		originalURL := "https://foo.bar/myPage?param1=value"
+		alteredURL := StripQueryParam(originalURL, "myParam")
+		tests.EvalObjectsWithLog(t, "stripped url", originalURL, alteredURL, []string{})
 	})
 
 }

--- a/pkg/utils/redirect_test.go
+++ b/pkg/utils/redirect_test.go
@@ -21,22 +21,36 @@ import (
 
 func TestStripQueryParam(t *testing.T) {
 
-	t.Run("removes a specific query param from a URL", func(t *testing.T) {
-		originalURL := "https://foo.bar/myPage?param1=value&param2=otherValue"
-		alteredURL := StripQueryParam(originalURL, "param2")
-		tests.EvalObjectsWithLog(t, "stripped url", "https://foo.bar/myPage?param1=value", alteredURL, []string{})
-	})
+	var testcases = []struct {
+		name  string
+		url   string
+		param string
+		want  string
+	}{
+		{
+			name:  "removes a specific query param from a URL",
+			url:   "https://foo.bar/myPage?param1=value&param2=otherValue",
+			param: "param2",
+			want:  "https://foo.bar/myPage?param1=value",
+		},
+		{
+			name:  "returns original URL if URL cannot be parsed",
+			url:   "glibberish",
+			param: "myParam",
+			want:  "glibberish",
+		},
+		{
+			name:  "returns original URL if param does not exist in URL",
+			url:   "https://foo.bar/myPage?param1=value",
+			param: "myParam",
+			want:  "https://foo.bar/myPage?param1=value",
+		},
+	}
 
-	t.Run("returns original URL if URL cannot be parsed", func(t *testing.T) {
-		originalURL := "glibberish"
-		alteredURL := StripQueryParam(originalURL, "myParam")
-		tests.EvalObjectsWithLog(t, "stripped url", originalURL, alteredURL, []string{})
-	})
-
-	t.Run("returns original URL if param does not exist in URL", func(t *testing.T) {
-		originalURL := "https://foo.bar/myPage?param1=value"
-		alteredURL := StripQueryParam(originalURL, "myParam")
-		tests.EvalObjectsWithLog(t, "stripped url", originalURL, alteredURL, []string{})
-	})
-
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			alteredURL := StripQueryParam(tc.url, tc.param)
+			tests.EvalObjectsWithLog(t, "stripped url", tc.want, alteredURL, []string{})
+		})
+	}
 }


### PR DESCRIPTION
This is following up on #217 by removing the login hint query parameter from the redirect URL if it is there.